### PR TITLE
feat: agregar vista de detalle de clase con opción de reserva

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-listado-clases />
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { ListadoClasesComponent } from "./features/clases/listado-clases/listado-clases.component";
 
 @Component({
   selector: 'app-root',
-  //imports: [RouterOutlet],
+  imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
-  imports: [ListadoClasesComponent]
 })
 export class AppComponent {
   title = 'fitzone-reservas';

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
+import { ListadoClasesComponent } from './features/clases/listado-clases/listado-clases.component';
+import { DetalleClaseComponent } from './features/clases/detalle-clase/detalle-clase.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+    { path: '', redirectTo: 'clases', pathMatch: 'full' },
+    { path: 'clases', component: ListadoClasesComponent },
+    { path: 'clases/:id', component: DetalleClaseComponent },
+    { path: '**', redirectTo: 'clases' }
+];

--- a/src/app/features/clases/detalle-clase/detalle-clase.component.html
+++ b/src/app/features/clases/detalle-clase/detalle-clase.component.html
@@ -1,0 +1,25 @@
+@let claseData = clase();
+
+@if(clasesResource.isLoading()){
+    <div>Cargando detalles...</div>
+}
+
+@if(clasesResource.error()){
+    <div>Error al cargar la clase</div>
+}
+
+@if(!clasesResource.isLoading() && claseData){
+    <h2>{{ claseData?.nombre }}</h2>
+    <p><strong>Tipo:</strong> {{ claseData?.tipo }}</p>
+    <p><strong>Ubicación:</strong> {{ claseData?.ubicacion }}</p>
+    <p><strong>Horario:</strong> {{ claseData?.horario | date: 'short' }}</p>
+    <!-- <p><strong>Descripción:</strong> {{ clase()?.descripcion }}</p> -->
+
+    <button (click)="reservar()">Reservar</button>
+    <button (click)="volver()">Volver</button>
+}
+
+@if(!clasesResource.isLoading() && !claseData){
+    <p>Clase no encontrada.</p>
+    <button (click)="volver()">Volver</button>
+}

--- a/src/app/features/clases/detalle-clase/detalle-clase.component.spec.ts
+++ b/src/app/features/clases/detalle-clase/detalle-clase.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DetalleClaseComponent } from './detalle-clase.component';
+
+describe('DetalleClaseComponent', () => {
+  let component: DetalleClaseComponent;
+  let fixture: ComponentFixture<DetalleClaseComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DetalleClaseComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DetalleClaseComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/clases/detalle-clase/detalle-clase.component.ts
+++ b/src/app/features/clases/detalle-clase/detalle-clase.component.ts
@@ -1,0 +1,48 @@
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { ClasesService } from '../../../core/services/clases.service';
+import { ActivatedRoute, RouterModule, Router } from '@angular/router';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'app-detalle-clase',
+  standalone: true,
+  imports: [DatePipe],
+  templateUrl: './detalle-clase.component.html',
+  styleUrl: './detalle-clase.component.css'
+})
+export class DetalleClaseComponent {
+  clasesService = inject(ClasesService)
+  route = inject(ActivatedRoute)
+  router = inject(Router)
+  idClase = signal<string | null>(null);
+
+  clasesResource = rxResource({
+    loader: () => this.clasesService.getClases()
+  });
+
+  clase = computed(() => {
+    const id = this.idClase();
+    const clases = this.clasesResource.value() ?? [];
+    return clases.find(c => c.id.toString() === id) ?? null;
+  });
+
+  constructor(){
+    this.idClase.set(this.route.snapshot.paramMap.get('id'));
+  }
+
+  volver() {
+    this.router.navigate(['/clases']);
+  }
+
+  reservar() {
+    if (this.clase()) {
+      const reservas = JSON.parse(localStorage.getItem('reservas') ?? '[]');
+      reservas.push(this.clase());
+      localStorage.setItem('reservas', JSON.stringify(reservas));
+      //alert('Clase reservada con éxito');
+
+      this.router.navigate(['/reservas']);
+    }
+  }
+}

--- a/src/app/features/clases/listado-clases/listado-clases.component.html
+++ b/src/app/features/clases/listado-clases/listado-clases.component.html
@@ -32,9 +32,11 @@
     <ul>
         @for (clase of clasesFiltradas(); track $index){
             <li>
-                <strong>{{ clase.nombre }}</strong> - {{ clase.tipo }}
-                <br>
-                <small>{{ clase.ubicacion }} | {{ clase.horario | date: 'short' }}</small>
+                <a [routerLink]="['/clases', clase.id]">
+                    <strong>{{ clase.nombre }}</strong> - {{ clase.tipo }}
+                    <br>
+                    <small>{{ clase.ubicacion }} | {{ clase.horario | date: 'short' }}</small>
+                </a>
             </li>
 
         }

--- a/src/app/features/clases/listado-clases/listado-clases.component.ts
+++ b/src/app/features/clases/listado-clases/listado-clases.component.ts
@@ -4,10 +4,12 @@ import { Clase } from '../../../core/models/clase.model';
 import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { rxResource } from '@angular/core/rxjs-interop';
+import { RouterLinkWithHref } from '@angular/router';
 
 @Component({
   selector: 'app-listado-clases',
-  imports: [DatePipe, FormsModule],
+  standalone: true,
+  imports: [DatePipe, FormsModule, RouterLinkWithHref],
   templateUrl: './listado-clases.component.html',
   styleUrl: './listado-clases.component.css'
 })


### PR DESCRIPTION
Este PR añade la vista de detalle para cada clase y permite a los usuarios reservarla, guardando la información en localStorage.

Cambios principales:

Integración de rxResource para carga reactiva de datos según el ID de la clase en la URL.

Uso de signal y computed para manejar estado y seleccionar la clase correspondiente.

Implementación del método reservar() que:

Guarda la clase seleccionada en localStorage.

Redirige automáticamente a la página Mis reservas después de reservar.

Enlaces en el listado para navegar a la vista de detalle.

Manejo de estados de carga y error en la vista de detalle.