### PR TITLE
feat(reservas): implementar vista de mis reservas con opción de cance…

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,10 +1,12 @@
 import { Routes } from '@angular/router';
 import { ListadoClasesComponent } from './features/clases/listado-clases/listado-clases.component';
 import { DetalleClaseComponent } from './features/clases/detalle-clase/detalle-clase.component';
+import { MisReservasComponent } from './features/reservas/mis-reservas/mis-reservas/mis-reservas.component';
 
 export const routes: Routes = [
     { path: '', redirectTo: 'clases', pathMatch: 'full' },
     { path: 'clases', component: ListadoClasesComponent },
     { path: 'clases/:id', component: DetalleClaseComponent },
+    { path: 'reservas', component: MisReservasComponent },
     { path: '**', redirectTo: 'clases' }
 ];

--- a/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.html
+++ b/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.html
@@ -1,0 +1,21 @@
+@let reservasData = reservas();
+
+<h2>Mis reservas</h2>
+
+@if(!hayReservas()){
+    <p>No tienes reservas</p>
+}
+
+@if(hayReservas()){
+    <ul>
+        @for(reserva of reservasData; track $index){
+            <li>
+                <strong>{{ reserva.nombre }}</strong> - {{ reserva.tipo }}
+                <br>
+                <small>{{ reserva.ubicacion }} | {{ reserva.horario | date: 'short' }}</small>
+                <br>
+                <button (click)="cancelarReserva(reserva.id)">Cancelar</button>
+            </li>
+        }
+    </ul>
+}

--- a/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.spec.ts
+++ b/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MisReservasComponent } from './mis-reservas.component';
+
+describe('MisReservasComponent', () => {
+  let component: MisReservasComponent;
+  let fixture: ComponentFixture<MisReservasComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MisReservasComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MisReservasComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.ts
+++ b/src/app/features/reservas/mis-reservas/mis-reservas/mis-reservas.component.ts
@@ -1,0 +1,29 @@
+import { Component, computed, signal } from '@angular/core';
+import { Clase } from '../../../../core/models/clase.model';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'app-mis-reservas',
+  imports: [DatePipe],
+  templateUrl: './mis-reservas.component.html',
+  styleUrl: './mis-reservas.component.css'
+})
+export class MisReservasComponent {
+  reservas = signal<Clase[]>([]);
+  hayReservas = computed(() => this.reservas().length > 0);
+
+  constructor(){
+    this.cargarReservas();
+  }
+
+  cargarReservas() {
+    const data = JSON.parse(localStorage.getItem('reservas') ?? '[]');
+    this.reservas.set(data);
+  }
+
+  cancelarReserva(id: number) {
+    const nuevasReservas = this.reservas().filter(r => r.id !== id);
+    this.reservas.set(nuevasReservas);
+    localStorage.setItem('reservas', JSON.stringify(nuevasReservas));
+  }
+}


### PR DESCRIPTION
Este PR implementa la página Mis reservas, permitiendo al usuario visualizar las clases reservadas y cancelarlas si lo desea.

Cambios principales:

- Creación de MisReservasComponent como componente standalone.

- Lectura inicial de reservas desde localStorage usando signal para manejo de estado.

- Implementación del método cancelarReserva() para:

     - Remover la clase seleccionada del array de reservas.

     - Actualizar automáticamente localStorage.
     
- Uso de computed para detectar si existen reservas y mostrar mensaje adecuado.